### PR TITLE
Fixed distclean Makefile rule

### DIFF
--- a/documentation/Makefile
+++ b/documentation/Makefile
@@ -50,4 +50,6 @@ clean:
 
 uninstall:
 
+realclean: clean
+
 # end


### PR DESCRIPTION
`make distclean` is not working properly because `documentation/Makefile` does not define `realclean` rule, this results in a cleaning error and build outputs not being cleaned properly. This will fix `make distclean` at the top-level directory and all build outputs are cleaned properly.